### PR TITLE
Update drillhole.pyx

### DIFF
--- a/cython_code/drillhole.pyx
+++ b/cython_code/drillhole.pyx
@@ -1974,7 +1974,7 @@ cdef class Drillhole:
                 z[i] = zs[jm[i]-1] - dz
                 
                
-            table.loc[c,'azme']  = azmt
+            table.loc[c,'azmm']  = azmt
             table.loc[c,'dipm']  = dipt
             table.loc[c,'xm']  = x
             table.loc[c,'ym']  = y


### PR DESCRIPTION
In the function desurvey_table while updating the values in the table, the incorrect column is getting updated for the mean (azm).